### PR TITLE
Fix comments key

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -274,7 +274,7 @@ defaults:
       layout: single
       author_profile: true
       share: true
-      comment: true
+      comments: true
   # _talks
   - scope:
       path: ""


### PR DESCRIPTION
## Summary
- fix `_config.yml` to use `comments:` key for portfolio defaults

## Testing
- `npm install`
- `npm run build:js`

------
https://chatgpt.com/codex/tasks/task_e_68635524e08c832880cafb0544d69589